### PR TITLE
Fix MTU problem detection

### DIFF
--- a/health.sh
+++ b/health.sh
@@ -574,7 +574,7 @@ check_mtu_issues() {
 
   local kw
   for kw in $mtu_dmesg_keywords; do
-    if grep -qiF -- "$kw" <<< "$dmesg_out"; then
+    if grep -qiFw -- "$kw" <<< "$dmesg_out"; then
       printf "MTU Issues: %s\n" "$(yellow_text 'Detected, check output from dmesg -T')"
       return 1
     fi


### PR DESCRIPTION
Added whole word match so that we don't get false positives with entries like this --
```
[Fri Jan 16 11:11:14 2026] ACPI: Actual Package length (24) is larger than NumElements field (20), truncated
```

Signed-off-by: Dan Pollak <danpollak2@gmail.com>